### PR TITLE
Downgrade rest client to v2.0

### DIFF
--- a/spec/api/message_spec.rb
+++ b/spec/api/message_spec.rb
@@ -52,7 +52,7 @@ describe Yammer::Api::Message do
   describe '#create_message' do
     it 'should create_message' do
       message = 'Greetings, we come in peace'
-      expect(subject).to receive(:post).with('/api/v1/messages', :body => message)
+      expect(subject).to receive(:post).with('/api/v1/messages', { body: message })
       subject.create_message(message)
     end
   end

--- a/yam.gemspec
+++ b/yam.gemspec
@@ -24,7 +24,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name             = 'yam'
-  s.version          = Yammer::Version
+  s.version          = Yammer::Version.to_s
 
   s.date             = Date.today.to_s
   s.summary          = "Yammer API Client"
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.authors          = ["Kevin Mutyaba"]
   s.email            = %q{kmutyaba@yammer-inc.com}
   s.homepage         = 'http://yammer.github.io/yam'
-  s.rubygems_version = Yammer::Version
+  s.rubygems_version = Yammer::Version.to_s
   s.files            = `git ls-files`.split("\n")
   s.require_paths    = ['lib']
 
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'oj', '~> 3.10'
   s.add_dependency 'multi_json', '~> 1.14'
-  s.add_dependency 'rest-client', '~> 2.1'
+  s.add_dependency 'rest-client', '~> 2.0.2'
   s.add_dependency 'addressable', '~> 2.7'
   s.add_dependency 'oauth2-client', '~> 2.0'
 


### PR DESCRIPTION
Downgrade rest client to 2.0.2 and fixed minor spec failure.

This PR resolves the version incompatibility issue faced when installing the gem after ruby upgrade to 3.3+.
Also, 2.1+ version of rest-client gem causes [this issue](https://github.com/rest-client/rest-client/issues/740).